### PR TITLE
Add metadata editor controls for posts and pages

### DIFF
--- a/includes/tabs/general/class-sbwscf-general-page.php
+++ b/includes/tabs/general/class-sbwscf-general-page.php
@@ -64,17 +64,22 @@ final class SBWSCF_General_Page implements SBWSCF_Tab_Interface {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 
 		$options = get_option( 'sbwscf_general_settings', array() );
-		if ( ! empty( $options['enable_svg'] ) ) {
-			// Activa el soporte SVG:.
-			require_once __DIR__ . '/svg-upload.php';
-			SBWSCF_SVG_Upload::init();
-		}
+                if ( ! empty( $options['enable_svg'] ) ) {
+                        // Activa el soporte SVG:.
+                        require_once __DIR__ . '/svg-upload.php';
+                        SBWSCF_SVG_Upload::init();
+                }
 
-		if ( ! empty( $options['enable_alt'] ) ) {
-			require_once __DIR__ . '/alt-text-upload.php';
-			SBWSCF_Auto_Alt_Text::init();
-		}
-	}
+                if ( ! empty( $options['enable_alt'] ) ) {
+                        require_once __DIR__ . '/alt-text-upload.php';
+                        SBWSCF_Auto_Alt_Text::init();
+                }
+
+                if ( ! empty( $options['enable_metadata'] ) ) {
+                        require_once __DIR__ . '/metadata-meta-box.php';
+                        SBWSCF_Metadata_Meta_Box::init();
+                }
+        }
 
 	/**
 	 * Encola CSS y JS sólo cuando estamos en la pestaña General.

--- a/includes/tabs/general/general-settings.php
+++ b/includes/tabs/general/general-settings.php
@@ -26,31 +26,48 @@ function sbwscf_general_register_settings(): void {
 		)
 	);
 
-	/* ---------- Sección ------------------------------------------------ */
-	add_settings_section(
-		'sbwscf_general_section',
-		esc_html__( 'General Settings', 'smile-basic-web' ),
-		'__return_false',
-		'sbwscf_general'
-	);
+        /* ---------- Sección ------------------------------------------------ */
+        add_settings_section(
+                'sbwscf_general_section',
+                esc_html__( 'General Settings', 'smile-basic-web' ),
+                '__return_false',
+                'sbwscf_general'
+        );
 
-	/* ---------- Campo: habilitar SVG ---------------------------------- */
-	add_settings_field(
-		'sbwscf_enable_svg',
+        /* ---------- Campo: habilitar SVG ---------------------------------- */
+        add_settings_field(
+                'sbwscf_enable_svg',
 		esc_html__( 'Enable SVG / SVGZ uploads', 'smile-basic-web' ),
 		'sbwscf_enable_svg_cb',
-		'sbwscf_general',
-		'sbwscf_general_section'
-	);
+                'sbwscf_general',
+                'sbwscf_general_section'
+        );
 
-	/* ---------- Campo: auto Alt-Text ---------------------------------- */
-	add_settings_field(
-		'sbwscf_enable_alt',
-		esc_html__( 'Auto-populate image Alt-Text from EXIF metadata', 'smile-basic-web' ),
-		'sbwscf_enable_alt_cb',
-		'sbwscf_general',
-		'sbwscf_general_section'
-	);
+        /* ---------- Campo: auto Alt-Text ---------------------------------- */
+        add_settings_field(
+                'sbwscf_enable_alt',
+                esc_html__( 'Auto-populate image Alt-Text from EXIF metadata', 'smile-basic-web' ),
+                'sbwscf_enable_alt_cb',
+                'sbwscf_general',
+                'sbwscf_general_section'
+        );
+
+        /* ---------- Sección Metadata ------------------------------------- */
+        add_settings_section(
+                'sbwscf_metadata_section',
+                esc_html__( 'Metadata', 'smile-basic-web' ),
+                '__return_false',
+                'sbwscf_general'
+        );
+
+        /* ---------- Campo: habilitar metadata ----------------------------- */
+        add_settings_field(
+                'sbwscf_enable_metadata',
+                esc_html__( 'Enable metadata editor for posts and pages', 'smile-basic-web' ),
+                'sbwscf_enable_metadata_cb',
+                'sbwscf_general',
+                'sbwscf_metadata_section'
+        );
 }
 
 /**
@@ -60,32 +77,33 @@ function sbwscf_general_register_settings(): void {
  * @return array           Sanitised values.
  */
 function sbwscf_general_sanitize( $input = null ): array {
-	$input = is_array( $input ) ? $input : array();
+        $input = is_array( $input ) ? $input : array();
 
-	return array(
-		'enable_svg' => isset( $input['enable_svg'] ) ? 1 : 0,
-		'enable_alt' => isset( $input['enable_alt'] ) ? 1 : 0,
-	);
+        return array(
+                'enable_svg'      => isset( $input['enable_svg'] ) ? 1 : 0,
+                'enable_alt'      => isset( $input['enable_alt'] ) ? 1 : 0,
+                'enable_metadata' => isset( $input['enable_metadata'] ) ? 1 : 0,
+        );
 }
 
-	/**
-	 * Callback para imprimir la casilla de "Enable SVG".
-	 *
-	 * @return void
-	 */
+/**
+ * Callback para imprimir la casilla de "Enable SVG".
+ *
+ * @return void
+ */
 function sbwscf_enable_svg_cb(): void {
 	$options    = get_option( 'sbwscf_general_settings', array() );
 	$checked    = ! empty( $options['enable_svg'] );
 	$field_id   = 'sbwscf_enable_svg';
 	$field_name = 'sbwscf_general_settings[enable_svg]';
 
-	printf(
-		'<label for="%1$s"><input type="checkbox" id="%1$s" name="%2$s" value="1" %3$s /> %4$s</label>',
-		esc_attr( $field_id ),
-		esc_attr( $field_name ),
-		checked( true, $checked, false ),
-		esc_html__( 'Allow uploading SVG and SVGZ files safely to media library.', 'smile-basic-web' )
-	);
+        printf(
+                '<label for="%1$s"><input type="checkbox" id="%1$s" name="%2$s" value="1" %3$s /> %4$s</label>',
+                esc_attr( $field_id ),
+                esc_attr( $field_name ),
+                checked( true, $checked, false ),
+                esc_html__( 'Allow uploading SVG and SVGZ files safely to media library.', 'smile-basic-web' )
+        );
 }
 
 /**
@@ -94,16 +112,36 @@ function sbwscf_enable_svg_cb(): void {
  * @return void
  */
 function sbwscf_enable_alt_cb(): void {
-	$options    = get_option( 'sbwscf_general_settings', array() );
-	$checked    = ! empty( $options['enable_alt'] );
-	$field_id   = 'sbwscf_enable_alt';
-	$field_name = 'sbwscf_general_settings[enable_alt]';
+        $options    = get_option( 'sbwscf_general_settings', array() );
+        $checked    = ! empty( $options['enable_alt'] );
+        $field_id   = 'sbwscf_enable_alt';
+        $field_name = 'sbwscf_general_settings[enable_alt]';
 
-	printf(
-		'<label for="%1$s"><input type="checkbox" id="%1$s" name="%2$s" value="1" %3$s /> %4$s</label>',
-		esc_attr( $field_id ),
-		esc_attr( $field_name ),
-		checked( true, $checked, false ),
-		esc_html__( 'Automatically copy the Alt Text Accessibility tag (or Title) from the EXIF metadata into the ALT field.', 'smile-basic-web' )
-	);
+        printf(
+                '<label for="%1$s"><input type="checkbox" id="%1$s" name="%2$s" value="1" %3$s /> %4$s</label>',
+                esc_attr( $field_id ),
+                esc_attr( $field_name ),
+                checked( true, $checked, false ),
+                esc_html__( 'Automatically copy the Alt Text Accessibility tag (or Title) from the EXIF metadata into the ALT field.', 'smile-basic-web' )
+        );
+}
+
+/**
+ * Print checkbox for enabling metadata editor.
+ *
+ * @return void
+ */
+function sbwscf_enable_metadata_cb(): void {
+        $options    = get_option( 'sbwscf_general_settings', array() );
+        $checked    = ! empty( $options['enable_metadata'] );
+        $field_id   = 'sbwscf_enable_metadata';
+        $field_name = 'sbwscf_general_settings[enable_metadata]';
+
+        printf(
+                '<label for="%1$s"><input type="checkbox" id="%1$s" name="%2$s" value="1" %3$s /> %4$s</label>',
+                esc_attr( $field_id ),
+                esc_attr( $field_name ),
+                checked( true, $checked, false ),
+                esc_html__( 'Display SEO metadata fields (title, description and indexation) on supported post types.', 'smile-basic-web' )
+        );
 }

--- a/includes/tabs/general/js/metadata-meta-box.js
+++ b/includes/tabs/general/js/metadata-meta-box.js
@@ -1,0 +1,26 @@
+(function () {
+        'use strict';
+
+        const initialiseCounter = function (field) {
+                const targetId = field.id;
+                if (!targetId) {
+                        return;
+                }
+
+                const counter = document.querySelector('[data-sbwscf-count-for="' + targetId + '"]');
+                if (!counter) {
+                        return;
+                }
+
+                const update = function () {
+                        counter.textContent = String(field.value.length);
+                };
+
+                update();
+                field.addEventListener('input', update);
+        };
+
+        document.addEventListener('DOMContentLoaded', function () {
+                document.querySelectorAll('[data-sbwscf-count-field]').forEach(initialiseCounter);
+        });
+}());

--- a/includes/tabs/general/metadata-meta-box.php
+++ b/includes/tabs/general/metadata-meta-box.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Conditional metadata editor for posts and pages.
+ *
+ * @package smile-basic-web
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/*
+ * ------------------------------------------------------------------
+ * Main class
+ * ------------------------------------------------------------------
+ */
+
+/**
+ * Registers meta box and saving logic for SEO metadata fields.
+ */
+final class SBWSCF_Metadata_Meta_Box {
+
+        /**
+         * Bootstraps hooks.
+         *
+         * @return void
+         */
+        public static function init(): void {
+                add_action( 'add_meta_boxes', array( __CLASS__, 'register_meta_box' ), 10, 2 );
+                add_action( 'save_post', array( __CLASS__, 'save_metadata' ) );
+                add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+        }
+
+        /*
+         * ------------------------------------------------------------------
+         * Meta box registration
+         * ------------------------------------------------------------------
+         */
+
+        /**
+         * Registers the metadata meta box for supported post types.
+         *
+         * @param string  $post_type Post type slug.
+         * @param WP_Post $post      Current post object.
+         * @return void
+         */
+        public static function register_meta_box( string $post_type, WP_Post $post ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( ! in_array( $post_type, self::get_supported_post_types(), true ) ) {
+                        return;
+                }
+
+                add_meta_box(
+                        'sbwscf_metadata_fields',
+                        esc_html__( 'Search Metadata', 'smile-basic-web' ),
+                        array( __CLASS__, 'render_meta_box' ),
+                        $post_type,
+                        'normal',
+                        'high'
+                );
+        }
+
+        /**
+         * Returns the list of post types that should display the meta box.
+         *
+         * @return array
+         */
+        private static function get_supported_post_types(): array {
+                $post_types = get_post_types(
+                        array(
+                                'show_ui' => true,
+                                'public'  => true,
+                        ),
+                        'names'
+                );
+
+                /**
+                 * Filters the post types that support the metadata editor.
+                 *
+                 * @param array $post_types Default supported post types.
+                 */
+                return apply_filters( 'sbwscf_metadata_post_types', $post_types );
+        }
+
+        /*
+         * ------------------------------------------------------------------
+         * Rendering
+         * ------------------------------------------------------------------
+         */
+
+        /**
+         * Renders the metadata meta box fields.
+         *
+         * @param WP_Post $post Post being edited.
+         * @return void
+         */
+        public static function render_meta_box( WP_Post $post ): void {
+                $meta_title       = get_post_meta( $post->ID, '_sbwscf_meta_title', true );
+                $meta_description = get_post_meta( $post->ID, '_sbwscf_meta_description', true );
+                $meta_index       = get_post_meta( $post->ID, '_sbwscf_meta_index', true );
+
+                $meta_title       = is_string( $meta_title ) ? $meta_title : '';
+                $meta_description = is_string( $meta_description ) ? $meta_description : '';
+                $meta_index       = 'noindex' === $meta_index ? 'noindex' : 'index';
+
+                $title_length       = self::get_character_length( $meta_title );
+                $description_length = self::get_character_length( $meta_description );
+
+                wp_nonce_field( 'sbwscf_metadata_meta_box', 'sbwscf_metadata_meta_box_nonce' );
+                ?>
+                <div class="sbwscf-metadata-field">
+                        <label for="sbwscf_meta_title"><strong><?php esc_html_e( 'Meta Title', 'smile-basic-web' ); ?></strong></label>
+                        <input
+                                type="text"
+                                id="sbwscf_meta_title"
+                                name="sbwscf_meta_title"
+                                value="<?php echo esc_attr( $meta_title ); ?>"
+                                class="widefat"
+                                maxlength="160"
+                                data-sbwscf-count-field="1"
+                        />
+                        <p class="description">
+                                <?php esc_html_e( 'Characters:', 'smile-basic-web' ); ?>
+                                <span class="sbwscf-char-count" data-sbwscf-count-for="sbwscf_meta_title"><?php echo esc_html( (string) $title_length ); ?></span>
+                                <?php esc_html_e( '(recommended 50–60).', 'smile-basic-web' ); ?>
+                        </p>
+                </div>
+                <div class="sbwscf-metadata-field">
+                        <label for="sbwscf_meta_description"><strong><?php esc_html_e( 'Meta Description', 'smile-basic-web' ); ?></strong></label>
+                        <textarea
+                                id="sbwscf_meta_description"
+                                name="sbwscf_meta_description"
+                                class="widefat"
+                                rows="4"
+                                data-sbwscf-count-field="1"
+                        ><?php echo esc_textarea( $meta_description ); ?></textarea>
+                        <p class="description">
+                                <?php esc_html_e( 'Characters:', 'smile-basic-web' ); ?>
+                                <span class="sbwscf-char-count" data-sbwscf-count-for="sbwscf_meta_description"><?php echo esc_html( (string) $description_length ); ?></span>
+                                <?php esc_html_e( '(recommended 120–160).', 'smile-basic-web' ); ?>
+                        </p>
+                </div>
+                <div class="sbwscf-metadata-field">
+                        <strong><?php esc_html_e( 'Indexing', 'smile-basic-web' ); ?></strong>
+                        <p>
+                                <label for="sbwscf_meta_index_yes">
+                                        <input
+                                                type="radio"
+                                                id="sbwscf_meta_index_yes"
+                                                name="sbwscf_meta_index"
+                                                value="index"
+                                                <?php checked( 'index', $meta_index ); ?>
+                                        />
+                                        <?php esc_html_e( 'Index in search engines', 'smile-basic-web' ); ?>
+                                </label>
+                        </p>
+                        <p>
+                                <label for="sbwscf_meta_index_no">
+                                        <input
+                                                type="radio"
+                                                id="sbwscf_meta_index_no"
+                                                name="sbwscf_meta_index"
+                                                value="noindex"
+                                                <?php checked( 'noindex', $meta_index ); ?>
+                                        />
+                                        <?php esc_html_e( 'Do not index (hide from search engines)', 'smile-basic-web' ); ?>
+                                </label>
+                        </p>
+                </div>
+                <?php
+        }
+
+        /*
+         * ------------------------------------------------------------------
+         * Saving
+         * ------------------------------------------------------------------
+         */
+
+        /**
+         * Persists metadata values when the post is saved.
+         *
+         * @param int $post_id Post ID.
+         * @return void
+         */
+        public static function save_metadata( int $post_id ): void {
+                if ( ! isset( $_POST['sbwscf_metadata_meta_box_nonce'] ) ) {
+                        return;
+                }
+
+                $nonce = sanitize_text_field( wp_unslash( $_POST['sbwscf_metadata_meta_box_nonce'] ) );
+                if ( ! wp_verify_nonce( $nonce, 'sbwscf_metadata_meta_box' ) ) {
+                        return;
+                }
+
+                if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+                        return;
+                }
+
+                $post_type = get_post_type( $post_id );
+                if ( ! $post_type || ! in_array( $post_type, self::get_supported_post_types(), true ) ) {
+                        return;
+                }
+
+                if ( ! current_user_can( 'edit_post', $post_id ) ) {
+                        return;
+                }
+
+                $meta_title = isset( $_POST['sbwscf_meta_title'] ) ? sanitize_text_field( wp_unslash( $_POST['sbwscf_meta_title'] ) ) : '';
+
+                $meta_description = isset( $_POST['sbwscf_meta_description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['sbwscf_meta_description'] ) ) : '';
+
+                $meta_index = isset( $_POST['sbwscf_meta_index'] ) ? sanitize_key( wp_unslash( $_POST['sbwscf_meta_index'] ) ) : 'index';
+                $meta_index = in_array( $meta_index, array( 'index', 'noindex' ), true ) ? $meta_index : 'index';
+
+                self::update_meta_value( $post_id, '_sbwscf_meta_title', $meta_title );
+                self::update_meta_value( $post_id, '_sbwscf_meta_description', $meta_description );
+                update_post_meta( $post_id, '_sbwscf_meta_index', $meta_index );
+        }
+
+        /**
+         * Updates or deletes a meta value based on its contents.
+         *
+         * @param int    $post_id Post ID.
+         * @param string $key     Meta key.
+         * @param string $value   Meta value.
+         * @return void
+         */
+        private static function update_meta_value( int $post_id, string $key, string $value ): void {
+                if ( '' === $value ) {
+                        delete_post_meta( $post_id, $key );
+                        return;
+                }
+
+                update_post_meta( $post_id, $key, $value );
+        }
+
+        /**
+         * Returns the number of characters in a string, multibyte-safe.
+         *
+         * @param string $value Value to measure.
+         * @return int
+         */
+        private static function get_character_length( string $value ): int {
+                if ( function_exists( 'mb_strlen' ) ) {
+                        return (int) mb_strlen( $value );
+                }
+
+                return strlen( $value );
+        }
+
+        /*
+         * ------------------------------------------------------------------
+         * Assets
+         * ------------------------------------------------------------------
+         */
+
+        /**
+         * Enqueues admin assets for the metadata meta box.
+         *
+         * @param string $hook_suffix Current admin page.
+         * @return void
+         */
+        public static function enqueue_assets( string $hook_suffix ): void {
+                if ( 'post.php' !== $hook_suffix && 'post-new.php' !== $hook_suffix ) {
+                        return;
+                }
+
+                $screen = get_current_screen();
+                if ( ! $screen || ! in_array( $screen->post_type, self::get_supported_post_types(), true ) ) {
+                        return;
+                }
+
+                wp_enqueue_script(
+                        'sbwscf-metadata-meta-box',
+                        SMILE_BASIC_WEB_PLUGIN_URL . 'includes/tabs/general/js/metadata-meta-box.js',
+                        array(),
+                        SMILE_BASIC_WEB_VERSION,
+                        true
+                );
+        }
+}


### PR DESCRIPTION
## Summary
- extend the General tab settings with a Metadata section that toggles SEO meta fields
- register a conditional admin meta box providing meta title, description and indexation options with counters
- enqueue a small vanilla JS helper to display live character counts in the metadata fields

## Testing
- php -l includes/tabs/general/metadata-meta-box.php

------
https://chatgpt.com/codex/tasks/task_e_68d505e276e88330b405287220cfd909