### PR TITLE
Enable front-end SEO metadata rendering

### DIFF
--- a/includes/tabs/general/class-sbwscf-general-page.php
+++ b/includes/tabs/general/class-sbwscf-general-page.php
@@ -60,10 +60,10 @@ final class SBWSCF_General_Page implements SBWSCF_Tab_Interface {
 	 *
 	 * @return void
 	 */
-	public static function load(): void {
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+        public static function load(): void {
+                add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 
-		$options = get_option( 'sbwscf_general_settings', array() );
+                $options = get_option( 'sbwscf_general_settings', array() );
                 if ( ! empty( $options['enable_svg'] ) ) {
                         // Activa el soporte SVG:.
                         require_once __DIR__ . '/svg-upload.php';
@@ -79,6 +79,25 @@ final class SBWSCF_General_Page implements SBWSCF_Tab_Interface {
                         require_once __DIR__ . '/metadata-meta-box.php';
                         SBWSCF_Metadata_Meta_Box::init();
                 }
+        }
+
+        /**
+         * Boot front-end specific features for the General tab.
+         *
+         * @return void
+         */
+        public static function boot_frontend_features(): void {
+                if ( is_admin() ) {
+                        return;
+                }
+
+                $options = get_option( 'sbwscf_general_settings', array() );
+                if ( empty( $options['enable_metadata'] ) ) {
+                        return;
+                }
+
+                require_once __DIR__ . '/metadata-meta-box.php';
+                SBWSCF_Metadata_Meta_Box::init_frontend();
         }
 
 	/**
@@ -118,3 +137,4 @@ final class SBWSCF_General_Page implements SBWSCF_Tab_Interface {
 
 // Hook para invocar load() tras inicializar Tab Manager.
 add_action( 'admin_init', array( 'SBWSCF_General_Page', 'load' ) );
+add_action( 'init', array( 'SBWSCF_General_Page', 'boot_frontend_features' ) );


### PR DESCRIPTION
## Summary
- load the metadata module on the front-end when the General setting is enabled
- render custom meta title, description, and robots directives for supported post types

## Testing
- php -l includes/tabs/general/class-sbwscf-general-page.php
- php -l includes/tabs/general/metadata-meta-box.php

------
https://chatgpt.com/codex/tasks/task_e_68d50e526a1083308dfb7d0dc9580628