### PR TITLE
Load General tab early to enable metadata output

### DIFF
--- a/smile-basic-web.php
+++ b/smile-basic-web.php
@@ -85,13 +85,15 @@ final class SMiLE_Basic_Web {
 	 * @return void
 	 */
 	private function includes(): void {
-		// Core interface & manager.
-		require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/core/interface-tab.php';
-		require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/core/class-sbwscf-tab-manager.php';
-		// Contact-Form tab class.
-		require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/tabs/contact-form/class-sbwscf-contactform-page.php';
-		// Sitemaps core – always load so rewrite rules persist.
-		require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/tabs/sitemaps/sitemaps.php';
+                // Core interface & manager.
+                require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/core/interface-tab.php';
+                require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/core/class-sbwscf-tab-manager.php';
+                // General tab class (needed early for front-end hooks).
+                require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/tabs/general/class-sbwscf-general-page.php';
+                // Contact-Form tab class.
+                require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/tabs/contact-form/class-sbwscf-contactform-page.php';
+                // Sitemaps core – always load so rewrite rules persist.
+                require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/tabs/sitemaps/sitemaps.php';
 		// Carga del tab “Cookies”.
 		require_once SMILE_BASIC_WEB_PLUGIN_PATH . 'includes/tabs/cookies/class-sbwscf-cookies-page.php';
 	}


### PR DESCRIPTION
## Summary
- load the General tab class during plugin bootstrap so its init hooks are registered before `init` runs
- ensure front-end meta title, description, and robots directives render when metadata is enabled

## Testing
- php -l smile-basic-web.php

------
https://chatgpt.com/codex/tasks/task_e_68d513b8867c8330bc3230d1c0192651