### PR TITLE
Add plugin version option to uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -35,6 +35,7 @@ function sbwscf_uninstall_site_cleanup() {
 		'sbwscf_priority_category',
 		'sbwscf_email_preview_page_id',
 		'sbwscf_general_settings', // <-- NUEVA entrada
+		'sbwscf_plugin_version',
 		// Cookies module options.
 		'sbwscf_enable_cookies_notice',
 		'sbwscf_cookie_message',


### PR DESCRIPTION
## Summary
- add the sbwscf_plugin_version entry to the uninstall cleanup option list so the version flag is removed on uninstall

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d527e74b5483308bc4b54c62924830