### PR TITLE
Add nofollow directive to SEO metadata toggle

### DIFF
--- a/includes/tabs/general/metadata-meta-box.php
+++ b/includes/tabs/general/metadata-meta-box.php
@@ -171,7 +171,7 @@ final class SBWSCF_Metadata_Meta_Box {
                                                 value="noindex"
                                                 <?php checked( 'noindex', $meta_index ); ?>
                                         />
-                                        <?php esc_html_e( 'Do not index (hide from search engines)', 'smile-basic-web' ); ?>
+                                        <?php esc_html_e( 'Do not index or follow (hide from search engines)', 'smile-basic-web' ); ?>
                                 </label>
                         </p>
                 </div>
@@ -327,10 +327,10 @@ final class SBWSCF_Metadata_Meta_Box {
                 }
 
                 unset( $robots['index'] );
-                unset( $robots['nofollow'] );
+                unset( $robots['follow'] );
 
-                $robots['noindex'] = true;
-                $robots['follow']  = true;
+                $robots['noindex']  = true;
+                $robots['nofollow'] = true;
 
                 return $robots;
         }


### PR DESCRIPTION
## Summary
- ensure the "Do not index" metadata option now outputs both noindex and nofollow directives
- clarify the radio button label to mention the nofollow behavior

## Testing
- php -l includes/tabs/general/metadata-meta-box.php

------
https://chatgpt.com/codex/tasks/task_e_68da5f5074108330bb52868b9005c6fe