### PR TITLE
Ensure custom meta descriptions replace default tagline output

### DIFF
--- a/includes/tabs/general/metadata-meta-box.php
+++ b/includes/tabs/general/metadata-meta-box.php
@@ -18,6 +18,20 @@ defined( 'ABSPATH' ) || exit;
  */
 final class SBWSCF_Metadata_Meta_Box {
 
+        /**
+         * Tracks whether we are inside wp_head() while a custom description exists.
+         *
+         * @var bool
+         */
+        private static bool $is_head_context = false;
+
+        /**
+         * Holds the meta description for the current request when available.
+         *
+         * @var string|null
+         */
+        private static ?string $current_meta_description = null;
+
 		/**
 		 * Bootstraps hooks.
 		 *
@@ -84,11 +98,14 @@ final class SBWSCF_Metadata_Meta_Box {
 		 *
 		 * @return void
 		 */
-	public static function init_frontend(): void {
-			add_filter( 'pre_get_document_title', array( __CLASS__, 'filter_document_title' ), 20 );
-			add_action( 'wp_head', array( __CLASS__, 'output_meta_tags' ), 1 );
-			add_filter( 'wp_robots', array( __CLASS__, 'filter_wp_robots' ) );
-	}
+        public static function init_frontend(): void {
+                        add_action( 'wp_head', array( __CLASS__, 'begin_head_context' ), 0 );
+                        add_filter( 'pre_get_document_title', array( __CLASS__, 'filter_document_title' ), 20 );
+                        add_action( 'wp_head', array( __CLASS__, 'output_meta_tags' ), 1 );
+                        add_filter( 'bloginfo', array( __CLASS__, 'filter_bloginfo_description' ), 10, 3 );
+                        add_filter( 'wp_robots', array( __CLASS__, 'filter_wp_robots' ) );
+                        add_action( 'wp_head', array( __CLASS__, 'end_head_context' ), PHP_INT_MAX );
+        }
 
 		/*
 		 * ------------------------------------------------------------------
@@ -236,47 +253,34 @@ final class SBWSCF_Metadata_Meta_Box {
 		 * @param string $title Default title.
 		 * @return string
 		 */
-	public static function filter_document_title( string $title ): string {
-		if ( ! is_singular( self::get_supported_post_types() ) ) {
-				return $title;
-		}
+        public static function filter_document_title( string $title ): string {
+                        $post_id = self::get_current_post_id();
+                if ( 0 === $post_id ) {
+                                return $title;
+                }
 
-			$post_id = get_queried_object_id();
-		if ( ! $post_id ) {
-				return $title;
-		}
+                        $meta_title = get_post_meta( $post_id, '_sbwscf_meta_title', true );
+                if ( ! is_string( $meta_title ) || '' === $meta_title ) {
+                                return $title;
+                }
 
-			$meta_title = get_post_meta( $post_id, '_sbwscf_meta_title', true );
-		if ( ! is_string( $meta_title ) || '' === $meta_title ) {
-				return $title;
-		}
-
-			return $meta_title;
-	}
+                        return $meta_title;
+        }
 
 		/**
 		 * Outputs the meta description in the document head.
 		 *
 		 * @return void
 		 */
-	public static function output_meta_tags(): void {
-		if ( ! is_singular( self::get_supported_post_types() ) ) {
-				return;
-		}
-
-			$post_id = get_queried_object_id();
-		if ( ! $post_id ) {
-				return;
-		}
-
-			$meta_description = get_post_meta( $post_id, '_sbwscf_meta_description', true );
-		if ( is_string( $meta_description ) && '' !== $meta_description ) {
-				printf(
-					"\n<meta name=\"description\" content=\"%s\" />\n",
-					esc_attr( $meta_description )
-				);
-		}
-	}
+        public static function output_meta_tags(): void {
+                        $meta_description = self::get_current_meta_description();
+                if ( '' !== $meta_description ) {
+                                printf(
+                                        "\n<meta name=\"description\" content=\"%s\" />\n",
+                                        esc_attr( $meta_description )
+                                );
+                }
+        }
 
 		/**
 		 * Adjusts robots directives so they are emitted through wp_robots().
@@ -284,20 +288,16 @@ final class SBWSCF_Metadata_Meta_Box {
 		 * @param array $robots Current robots directives.
 		 * @return array
 		 */
-	public static function filter_wp_robots( array $robots ): array {
-		if ( ! is_singular( self::get_supported_post_types() ) ) {
-				return $robots;
-		}
+        public static function filter_wp_robots( array $robots ): array {
+                        $post_id = self::get_current_post_id();
+                if ( 0 === $post_id ) {
+                                return $robots;
+                }
 
-			$post_id = get_queried_object_id();
-		if ( ! $post_id ) {
-				return $robots;
-		}
-
-			$meta_index = get_post_meta( $post_id, '_sbwscf_meta_index', true );
-		if ( 'noindex' !== $meta_index ) {
-				return $robots;
-		}
+                        $meta_index = get_post_meta( $post_id, '_sbwscf_meta_index', true );
+                if ( 'noindex' !== $meta_index ) {
+                                return $robots;
+                }
 
 			unset( $robots['index'] );
 			unset( $robots['follow'] );
@@ -311,31 +311,115 @@ final class SBWSCF_Metadata_Meta_Box {
 		/*
 		 * ------------------------------------------------------------------
 		 * Assets
-		 * ------------------------------------------------------------------
-		 */
+         * ------------------------------------------------------------------
+         */
 
-		/**
-		 * Enqueues admin assets for the metadata meta box.
-		 *
-		 * @param string $hook_suffix Current admin page.
-		 * @return void
-		 */
-	public static function enqueue_assets( string $hook_suffix ): void {
-		if ( 'post.php' !== $hook_suffix && 'post-new.php' !== $hook_suffix ) {
-				return;
-		}
+        /**
+         * Marks the start of wp_head() so description filtering only happens there.
+         *
+         * @return void
+         */
+        public static function begin_head_context(): void {
+                        $meta_description = self::get_current_meta_description();
+                if ( '' === $meta_description ) {
+                                self::$is_head_context       = false;
+                                self::$current_meta_description = null;
+                                return;
+                }
 
-			$screen = get_current_screen();
-		if ( ! $screen || ! in_array( $screen->post_type, self::get_supported_post_types(), true ) ) {
-				return;
-		}
+                        self::$is_head_context       = true;
+                        self::$current_meta_description = $meta_description;
+        }
 
-			wp_enqueue_script(
-				'sbwscf-metadata-meta-box',
-				SMILE_BASIC_WEB_PLUGIN_URL . 'includes/tabs/general/js/metadata-meta-box.js',
-				array(),
-				SMILE_BASIC_WEB_VERSION,
-				true
-			);
-	}
+        /**
+         * Filters bloginfo() so themes output the custom meta description instead of the tagline.
+         *
+         * @param string $value  Original value.
+         * @param string $show   Requested field.
+         * @param string $filter Context filter (raw/display).
+         * @return string
+         */
+        public static function filter_bloginfo_description( string $value, string $show, string $filter ): string { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( 'description' !== $show ) {
+                                return $value;
+                }
+
+                if ( ! self::$is_head_context || null === self::$current_meta_description ) {
+                                return $value;
+                }
+
+                        return self::$current_meta_description;
+        }
+
+        /**
+         * Resets head-context flags after wp_head() has finished rendering.
+         *
+         * @return void
+         */
+        public static function end_head_context(): void {
+                        self::$is_head_context       = false;
+                        self::$current_meta_description = null;
+        }
+
+        /**
+         * Enqueues admin assets for the metadata meta box.
+         *
+         * @param string $hook_suffix Current admin page.
+         * @return void
+         */
+        public static function enqueue_assets( string $hook_suffix ): void {
+                if ( 'post.php' !== $hook_suffix && 'post-new.php' !== $hook_suffix ) {
+                                return;
+                }
+
+                        $screen = get_current_screen();
+                if ( ! $screen || ! in_array( $screen->post_type, self::get_supported_post_types(), true ) ) {
+                                return;
+                }
+
+                        wp_enqueue_script(
+                                'sbwscf-metadata-meta-box',
+                                SMILE_BASIC_WEB_PLUGIN_URL . 'includes/tabs/general/js/metadata-meta-box.js',
+                                array(),
+                                SMILE_BASIC_WEB_VERSION,
+                                true
+                        );
+        }
+
+        /**
+         * Returns the current post ID when displaying a supported singular post.
+         *
+         * @return int
+         */
+        private static function get_current_post_id(): int {
+                if ( ! is_singular( self::get_supported_post_types() ) ) {
+                                return 0;
+                }
+
+                        $post_id = get_queried_object_id();
+                if ( ! $post_id ) {
+                                return 0;
+                }
+
+                        return (int) $post_id;
+        }
+
+        /**
+         * Retrieves the saved meta description for the current request.
+         *
+         * @return string
+         */
+        private static function get_current_meta_description(): string {
+                        $post_id = self::get_current_post_id();
+                if ( 0 === $post_id ) {
+                                return '';
+                }
+
+                        $meta_description = get_post_meta( $post_id, '_sbwscf_meta_description', true );
+                if ( ! is_string( $meta_description ) ) {
+                                return '';
+                }
+
+                        return $meta_description;
+        }
 }


### PR DESCRIPTION
## Summary
- add head-context tracking so themes calling `bloginfo('description')` inside `wp_head` receive the saved meta description
- reuse helper methods for resolving the current post and description when filtering the document title and robots directives
- keep emitting the custom `<meta name="description">` tag while preventing duplicate tagline-based meta descriptions

## Testing
- php -l includes/tabs/general/metadata-meta-box.php

------
https://chatgpt.com/codex/tasks/task_e_68da7d8c698083309e78ca8b0bebd24a