### PR TITLE
Handle missing SVG metadata

### DIFF
--- a/includes/tabs/general/svg-upload.php
+++ b/includes/tabs/general/svg-upload.php
@@ -230,19 +230,22 @@ final class SBWSCF_SVG_Upload {
 	* ------------------------------------------------------------------
 	*/
 
-	/**
-	 * Provide thumbnail for SVGs.
-	 *
-	 * @param array   $response   Prepared data.
-	 * @param WP_Post $attachment Attachment post.
-	 * @param array   $meta       Metadata.
-	 * @return array              Modified data.
-	 */
-	public static function svg_preview( array $response, WP_Post $attachment, array $meta ): array {
-		unset( $meta );
-		if ( isset( $response['mime'] ) && 'image/svg+xml' === $response['mime'] ) { // Yoda.
-			$response['thumb']  = esc_url( wp_get_attachment_url( $attachment->ID ) );
-			$response['width']  = 0;
+        /**
+         * Provide thumbnail for SVGs.
+         *
+         * @param array       $response   Prepared data.
+         * @param WP_Post     $attachment Attachment post.
+         * @param array|false $meta       Metadata.
+         * @return array                  Modified data.
+         */
+        public static function svg_preview( array $response, WP_Post $attachment, $meta ): array {
+                if ( ! is_array( $meta ) ) {
+                        $meta = array();
+                }
+                unset( $meta );
+                if ( isset( $response['mime'] ) && 'image/svg+xml' === $response['mime'] ) { // Yoda.
+                        $response['thumb']  = esc_url( wp_get_attachment_url( $attachment->ID ) );
+                        $response['width']  = 0;
 			$response['height'] = 0;
 		}
 		return $response;


### PR DESCRIPTION
## Summary
- allow `svg_preview` to accept missing metadata from `wp_prepare_attachment_for_js`
- document the broader metadata types supported by the filter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2eb8795c8330b21f351057eec7a8