### PR TITLE
Bump plugin version to 1.3.6

### DIFF
--- a/smile-basic-web.php
+++ b/smile-basic-web.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: SMiLE Basic Web
  * Description: Modular plugin bundling the Contact-Form and Sitemaps features.
- * Version:     1.3.5
+ * Version:     1.3.6
  * Requires at least: 6.3
  * Requires PHP:      7.4
  * Author:      smilecomunicacion
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit; // Prevent direct access.
 define( 'SMILE_BASIC_WEB_PLUGIN_FILE', __FILE__ );
 define( 'SMILE_BASIC_WEB_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SMILE_BASIC_WEB_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'SMILE_BASIC_WEB_VERSION', '1.3.5' );
+define( 'SMILE_BASIC_WEB_VERSION', '1.3.6' );
 
 /**
  * Main plugin singleton.


### PR DESCRIPTION
## Summary
- update the plugin header version to 1.3.6
- bump the SMILE_BASIC_WEB_VERSION constant to 1.3.6 to keep runtime metadata aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3bdfe0d083308c46696e16e4c77c