### PR TITLE
Fix general settings sanitization for unchecked options

### DIFF
--- a/includes/tabs/general/general-settings.php
+++ b/includes/tabs/general/general-settings.php
@@ -79,11 +79,11 @@ function sbwscf_general_register_settings(): void {
 function sbwscf_general_sanitize( $input = null ): array {
 		$input = is_array( $input ) ? $input : array();
 
-		return array(
-			'enable_svg'      => isset( $input['enable_svg'] ) ? 1 : 0,
-			'enable_alt'      => isset( $input['enable_alt'] ) ? 1 : 0,
-			'enable_metadata' => isset( $input['enable_metadata'] ) ? 1 : 0,
-		);
+        return array(
+                'enable_svg'      => ! empty( $input['enable_svg'] ) ? 1 : 0,
+                'enable_alt'      => ! empty( $input['enable_alt'] ) ? 1 : 0,
+                'enable_metadata' => ! empty( $input['enable_metadata'] ) ? 1 : 0,
+        );
 }
 
 /**


### PR DESCRIPTION
## Summary
- update the general settings sanitization routine to evaluate actual checkbox values
- ensure unchecked checkboxes (value `0`) persist as `0` instead of defaulting to `1`

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de43542cb0833082190328bd5fa5fc