### PR TITLE
Adjust consent instructions selector specificity

### DIFF
--- a/includes/tabs/contact-form/customizer.php
+++ b/includes/tabs/contact-form/customizer.php
@@ -454,9 +454,10 @@ function sbwscf_contactform_output_customizer_css() {
         color: <?php echo esc_attr( $label_font_color ); ?>;
 }
 
-.sbwscf-consent-instructions {
-        color: <?php echo esc_attr( $consent_instructions_font_color ); ?>;
-        font-size: <?php echo esc_attr( $consent_instructions_font_size ); ?>;
+section .sbwscf-contact-form p.sbwscf-consent-instructions,
+.sbwscf-contact-form .sbwscf-consent-instructions {
+       color: <?php echo esc_attr( $consent_instructions_font_color ); ?> !important;
+       font-size: <?php echo esc_attr( $consent_instructions_font_size ); ?>;
 }
 
 /* ==================== */


### PR DESCRIPTION
## Summary
- update the consent instructions rule with a more specific selector so it wins against section-level styles
- add !important to the consent instructions color so the Customizer value always applies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50aa8aa7c8330ba2aa1ded441d7f6