### PR TITLE
Allow formatted content in form explanation settings

### DIFF
--- a/includes/tabs/contact-form/contact-form-settings.php
+++ b/includes/tabs/contact-form/contact-form-settings.php
@@ -80,7 +80,9 @@ function smile_basic_web_sanitize_settings( $input ): array {
 	? sanitize_textarea_field( $input['marketing_text'] )
 	: '';
 	// Explanation & footer.
-        $sanitized['form_explanation']     = isset( $input['form_explanation'] ) ? sanitize_textarea_field( $input['form_explanation'] ) : '';
+        $sanitized['form_explanation']     = isset( $input['form_explanation'] )
+                ? wp_kses_post( $input['form_explanation'] )
+                : '';
         $sanitized['consent_instructions'] = isset( $input['consent_instructions'] ) ? sanitize_textarea_field( $input['consent_instructions'] ) : '';
         $sanitized['footer_notice']        = isset( $input['footer_notice'] ) ? sanitize_textarea_field( $input['footer_notice'] ) : '';
 	// reCAPTCHA.
@@ -547,10 +549,20 @@ function smile_basic_web_render_marketing_text_field() {
  */
 function smile_basic_web_render_form_explanation_field() {
         $options = get_option( 'sbwscf_settings', array() );
+        $content = isset( $options['form_explanation'] ) ? wp_kses_post( $options['form_explanation'] ) : '';
+
+        wp_editor(
+                $content,
+                'sbwscf_form_explanation',
+                array(
+                        'textarea_name' => 'sbwscf_settings[form_explanation]',
+                        'textarea_rows' => 8,
+                        'teeny'         => true,
+                        'media_buttons' => false,
+                )
+        );
         ?>
-<textarea name="sbwscf_settings[form_explanation]" rows="4" cols="50"
-        class="large-text"><?php echo esc_textarea( $options['form_explanation'] ?? '' ); ?></textarea>
-<p class="description"><?php esc_html_e( 'Text explaining the purpose of the contact form.', 'smile-basic-web' ); ?></p>
+<p class="description"><?php esc_html_e( 'Use formatting to explain the purpose of the contact form.', 'smile-basic-web' ); ?></p>
         <?php
 }
 

--- a/includes/tabs/contact-form/contact-form.php
+++ b/includes/tabs/contact-form/contact-form.php
@@ -305,7 +305,11 @@ if ( ! class_exists( 'SMiLE_Contact_Form' ) ) :
 			<?php if ( ! empty( $settings['form_explanation'] ) ) : ?>
 		<p class="sbwscf-form-explanation">
 			<label>
-				<?php echo wp_kses_post( nl2br( $settings['form_explanation'] ) ); ?>
+                                <?php
+                                $explanation = isset( $settings['form_explanation'] ) ? wp_kses_post( $settings['form_explanation'] ) : '';
+                                $explanation = wpautop( $explanation );
+                                echo wp_kses_post( $explanation );
+                                ?>
 			</label>
 		</p>
 		<?php endif; ?>


### PR DESCRIPTION
## Summary
- allow HTML content in the form explanation setting by sanitizing with `wp_kses_post`
- replace the plain textarea with `wp_editor` so administrators can format the explanation text
- render the stored explanation with `wpautop` on the front end to preserve the chosen formatting

## Testing
- php -l includes/tabs/contact-form/contact-form-settings.php
- php -l includes/tabs/contact-form/contact-form.php


------
https://chatgpt.com/codex/tasks/task_e_68e637cc245c833080ae78876d9f1320