### PR TITLE
Update readme for 1.3.8 release

### DIFF
--- a/includes/tabs/contact-form/contact-form-settings.php
+++ b/includes/tabs/contact-form/contact-form-settings.php
@@ -80,7 +80,9 @@ function smile_basic_web_sanitize_settings( $input ): array {
 	? sanitize_textarea_field( $input['marketing_text'] )
 	: '';
 	// Explanation & footer.
-        $sanitized['form_explanation']     = isset( $input['form_explanation'] ) ? sanitize_textarea_field( $input['form_explanation'] ) : '';
+        $sanitized['form_explanation']     = isset( $input['form_explanation'] )
+                ? wp_kses_post( $input['form_explanation'] )
+                : '';
         $sanitized['consent_instructions'] = isset( $input['consent_instructions'] ) ? sanitize_textarea_field( $input['consent_instructions'] ) : '';
         $sanitized['footer_notice']        = isset( $input['footer_notice'] ) ? sanitize_textarea_field( $input['footer_notice'] ) : '';
 	// reCAPTCHA.
@@ -547,10 +549,20 @@ function smile_basic_web_render_marketing_text_field() {
  */
 function smile_basic_web_render_form_explanation_field() {
         $options = get_option( 'sbwscf_settings', array() );
+        $content = isset( $options['form_explanation'] ) ? wp_kses_post( $options['form_explanation'] ) : '';
+
+        wp_editor(
+                $content,
+                'sbwscf_form_explanation',
+                array(
+                        'textarea_name' => 'sbwscf_settings[form_explanation]',
+                        'textarea_rows' => 8,
+                        'teeny'         => true,
+                        'media_buttons' => false,
+                )
+        );
         ?>
-<textarea name="sbwscf_settings[form_explanation]" rows="4" cols="50"
-        class="large-text"><?php echo esc_textarea( $options['form_explanation'] ?? '' ); ?></textarea>
-<p class="description"><?php esc_html_e( 'Text explaining the purpose of the contact form.', 'smile-basic-web' ); ?></p>
+<p class="description"><?php esc_html_e( 'Use formatting to explain the purpose of the contact form.', 'smile-basic-web' ); ?></p>
         <?php
 }
 

--- a/includes/tabs/contact-form/contact-form.php
+++ b/includes/tabs/contact-form/contact-form.php
@@ -305,7 +305,11 @@ if ( ! class_exists( 'SMiLE_Contact_Form' ) ) :
 			<?php if ( ! empty( $settings['form_explanation'] ) ) : ?>
 		<p class="sbwscf-form-explanation">
 			<label>
-				<?php echo wp_kses_post( nl2br( $settings['form_explanation'] ) ); ?>
+                                <?php
+                                $explanation = isset( $settings['form_explanation'] ) ? wp_kses_post( $settings['form_explanation'] ) : '';
+                                $explanation = wpautop( $explanation );
+                                echo wp_kses_post( $explanation );
+                                ?>
 			</label>
 		</p>
 		<?php endif; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: smilecomunicacion
 Tags: contact, reCAPTCHA, SMTP, sitemaps, svg
 Requires at least: 6.3
 Tested up to: 6.8
-Stable tag: 1.3.7
+Stable tag: 1.3.8
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -110,6 +110,11 @@ Absolutely. You can register any custom script in the admin panel, along with a 
 
 == Changelog ==
 
+= 1.3.8 =
+* NEW: Upgraded the Form Explanation setting to use the WordPress editor for bold text, separators, and other formatting.
+* UPDATED: Store formatted explanations with `wp_kses_post()` so only trusted HTML is saved.
+* UPDATED: Render explanation content with `wpautop()` to preserve administrator formatting on the front end.
+
 = 1.3.7 =
 * NEW: Added a consent instructions field so site owners can clarify data usage directly in the form.
 * UPDATED: Introduced style controls in the WordPress Customizer to fine-tune consent panel typography and colors.
@@ -187,6 +192,9 @@ Absolutely. You can register any custom script in the admin panel, along with a 
 * Integrated Google reCAPTCHA v3.
 
 == Upgrade Notice ==
+
+= 1.3.8 =
+Upgrade to let administrators format the form explanation with headings, lists, and other safe HTML while ensuring the public view matches their layout.
 
 = 1.3.7 =
 Customize the consent experience with new instructions and appearance controls directly in the Customizer, improving clarity for visitors.


### PR DESCRIPTION
## Summary
- bump the stable tag in `readme.txt` to 1.3.8
- add 1.3.8 entries to the changelog and upgrade notice highlighting the new form explanation formatting features

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e637cc245c833080ae78876d9f1320