### PR TITLE
Adjust form explanation markup and styling

### DIFF
--- a/includes/tabs/contact-form/contact-form.php
+++ b/includes/tabs/contact-form/contact-form.php
@@ -302,17 +302,15 @@ if ( ! class_exists( 'SMiLE_Contact_Form' ) ) :
 		</p>
 		<?php endif; ?>
 
-			<?php if ( ! empty( $settings['form_explanation'] ) ) : ?>
-		<p class="sbwscf-form-explanation">
-			<label>
-								<?php
-								$explanation = isset( $settings['form_explanation'] ) ? wp_kses_post( $settings['form_explanation'] ) : '';
-								$explanation = wpautop( $explanation );
-								echo wp_kses_post( $explanation );
-								?>
-			</label>
-		</p>
-		<?php endif; ?>
+                        <?php if ( ! empty( $settings['form_explanation'] ) ) : ?>
+                <div class="sbwscf-form-explanation">
+                        <?php
+                        $explanation = isset( $settings['form_explanation'] ) ? wp_kses_post( $settings['form_explanation'] ) : '';
+                        $explanation = wpautop( $explanation );
+                        echo wp_kses_post( $explanation );
+                        ?>
+                </div>
+                <?php endif; ?>
 
 		<div id="sbwscf-form-messages"></div>
 

--- a/includes/tabs/contact-form/customizer.php
+++ b/includes/tabs/contact-form/customizer.php
@@ -212,14 +212,19 @@ function sbwscf_contactform_customize_register( WP_Customize_Manager $wp_customi
                        'label'   => esc_html__( 'Consent Instructions Font Size', 'smile-basic-web' ),
                        'type'    => 'text',
                ),
-               // Nuevo: Tamaño de fuente para el texto explicativo.
-               'sbwscf_form_explanation_font_size'  => array(
-                       'default' => '14px',
-                       'label'   => esc_html__( 'Form Explanation Font Size', 'smile-basic-web' ),
-                       'type'    => 'text',
-		),
-		// 7. Submit button.
-		'sbwscf_submit_button_color'         => array(
+                // Nuevo: Tamaño de fuente para el texto explicativo.
+                'sbwscf_form_explanation_font_size'   => array(
+                        'default' => '14px',
+                        'label'   => esc_html__( 'Form Explanation Font Size', 'smile-basic-web' ),
+                        'type'    => 'text',
+                ),
+                'sbwscf_form_explanation_font_color' => array(
+                        'default' => '#666666',
+                        'label'   => esc_html__( 'Form Explanation Font Color', 'smile-basic-web' ),
+                        'type'    => 'color',
+                ),
+                // 7. Submit button.
+                'sbwscf_submit_button_color'         => array(
 			'default' => '#2b71f2',
 			'label'   => esc_html__( 'Submit Button Background Color', 'smile-basic-web' ),
 			'type'    => 'color',
@@ -376,6 +381,8 @@ function sbwscf_contactform_output_customizer_css() {
        $label_font_weight                   = get_theme_mod( 'sbwscf_label_font_weight', 'normal' );
        $consent_instructions_font_color     = get_theme_mod( 'sbwscf_consent_instructions_font_color', '#666666' );
        $consent_instructions_font_size      = get_theme_mod( 'sbwscf_consent_instructions_font_size', '14px' );
+       $form_explanation_font_size          = get_theme_mod( 'sbwscf_form_explanation_font_size', '14px' );
+       $form_explanation_font_color         = get_theme_mod( 'sbwscf_form_explanation_font_color', '#666666' );
 
 	// 2. Inputs.
 	$input_font_size   = get_theme_mod( 'sbwscf_input_font_size', '16px' );
@@ -449,9 +456,17 @@ function sbwscf_contactform_output_customizer_css() {
 }
 
 /* Nueva regla para el Texto explicativo de los fines del formulario */
-.sbwscf-form-explanation label{
-        font-size: <?php echo esc_attr( get_theme_mod( 'sbwscf_form_explanation_font_size', '14px' ) ); ?>;
-        color: <?php echo esc_attr( $label_font_color ); ?>;
+.sbwscf-contact-form .sbwscf-form-explanation {
+        font-size: <?php echo esc_attr( $form_explanation_font_size ); ?>;
+        color: <?php echo esc_attr( $form_explanation_font_color ); ?>;
+}
+
+.sbwscf-contact-form .sbwscf-form-explanation p {
+        font-size: inherit;
+}
+
+section .sbwscf-contact-form .sbwscf-form-explanation p:not(.text-emphasis):not(.h2) {
+        color: <?php echo esc_attr( $form_explanation_font_color ); ?>;
 }
 
 section .sbwscf-contact-form p.sbwscf-consent-instructions,


### PR DESCRIPTION
## Summary
- remove the deprecated label wrapper from the form explanation output so it renders cleanly
- add a customizable font color alongside the existing font size control for the form explanation text
- update the generated CSS to target the new markup and provide sufficient specificity to override theme defaults

## Testing
- php -l includes/tabs/contact-form/contact-form.php
- php -l includes/tabs/contact-form/customizer.php

------
https://chatgpt.com/codex/tasks/task_e_68e665d0cf988330b7de281fb176196b