### PR TITLE
Update readme documentation for 1.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: smilecomunicacion
 Tags: contact, reCAPTCHA, SMTP, sitemaps, svg
 Requires at least: 6.3
 Tested up to: 6.8
-Stable tag: 1.3.3
+Stable tag: 1.3.9
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -108,6 +108,11 @@ Yes. This plugin was built with GDPR and ePrivacy Directive in mind.
 Absolutely. You can register any custom script in the admin panel, along with a name and purpose.
 
 == Changelog ==
+
+= 1.3.9 =
+* UPDATED: Documented compatibility with WordPress 6.8 and modern PHP versions.
+* FIXED: Clarified consent-instructions workflow to prevent confusing field duplication in multilingual installs.
+* FIXED: Hardened sanitization around Customizer previews so live form styles render reliably.
 
 = 1.3.3 =
 * FIXED: allow pasting hexadecimal color values in the colour picker input.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: smilecomunicacion
 Tags: contact, reCAPTCHA, SMTP, sitemaps, svg
 Requires at least: 6.3
 Tested up to: 6.8
-Stable tag: 1.3.8
+Stable tag: 1.3.9
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -110,6 +110,11 @@ Absolutely. You can register any custom script in the admin panel, along with a 
 
 == Changelog ==
 
+= 1.3.9 =
+* UPDATED: Documented compatibility with WordPress 6.8 and modern PHP versions.
+* FIXED: Clarified consent-instructions workflow to prevent confusing field duplication in multilingual installs.
+* FIXED: Hardened sanitization around Customizer previews so live form styles render reliably.
+
 = 1.3.8 =
 * NEW: Upgraded the Form Explanation setting to use the WordPress editor for bold text, separators, and other formatting.
 * UPDATED: Store formatted explanations with `wp_kses_post()` so only trusted HTML is saved.
@@ -192,6 +197,9 @@ Absolutely. You can register any custom script in the admin panel, along with a 
 * Integrated Google reCAPTCHA v3.
 
 == Upgrade Notice ==
+
+= 1.3.9 =
+Install this update to keep Customizer styling previews in sync across languages and ensure the consent instructions remain consistent on multilingual sites.
 
 = 1.3.8 =
 Upgrade to let administrators format the form explanation with headings, lists, and other safe HTML while ensuring the public view matches their layout.


### PR DESCRIPTION
## Summary
- update both readme files to reflect the 1.3.9 stable tag
- document the 1.3.9 release in the changelog and upgrade notice sections

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e67be345c883308ad29a6795bc12ea