### PR TITLE
Refine cookie category header layout

### DIFF
--- a/includes/tabs/cookies/assets/css/smile-cookies.css
+++ b/includes/tabs/cookies/assets/css/smile-cookies.css
@@ -301,45 +301,98 @@
 	display: none !important;
 }
 
+
+
 .sbwscf-cookie-category {
-	border: 1px solid #ddd;
-	border-radius: 6px;
-	overflow: hidden;
-	background-color: #fff;
+        position: relative;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        overflow: hidden;
+        background-color: #fff;
+        --sbwscf-toggle-width: clamp(150px, 32%, 220px);
+}
+
+.sbwscf-cookie-accordion {
+        margin: 0;
 }
 
 .sbwscf-cookie-summary {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	cursor: pointer;
-	padding: 0.75rem 1rem;
-	font-weight: 400;
-	background-color: #f0f0f0;
-	color: var(--sbwscf-text-color);
+        display: block;
+        cursor: pointer;
+        padding: 0.75rem 1rem;
+        padding-right: calc(var(--sbwscf-toggle-width) + 1rem);
+        font-weight: 400;
+        background-color: #f0f0f0;
+        color: var(--sbwscf-text-color);
+}
+
+.sbwscf-cookie-accordion[open] .sbwscf-cookie-summary {
+        border-bottom: 1px solid #ddd;
 }
 
 .sbwscf-cookie-title {
-	display: inline-block;
-	font-size: 1rem;
-	line-height: 1.2rem;
-	color: var(--sbwscf-title-color);
-	padding-right: 0.5rem;
+        display: inline-block;
+        font-size: 1rem;
+        line-height: 1.2rem;
+        color: var(--sbwscf-title-color);
+        padding-right: 0.5rem;
+}
+
+.sbwscf-cookie-toggle {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: var(--sbwscf-toggle-width);
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        padding: 0.75rem 1rem;
+        background-color: #f0f0f0;
+        border-left: 1px solid #ddd;
+        z-index: 1;
+}
+
+.sbwscf-cookie-accordion[open] ~ .sbwscf-cookie-toggle {
+        border-bottom: 1px solid #ddd;
 }
 
 .sbwscf-cookie-checkbox {
-	display: flex;
-	align-items: center;
-	font-size: 1.2em;
-	gap: 0.5rem;
+        display: flex;
+        align-items: center;
+        font-size: 1.2em;
+        gap: 0.5rem;
 }
 
 .sbwscf-cookie-description {
-	padding: 1rem;
-	background-color: #f8f8f8;
-	font-size: 0.9rem;
-	line-height: 1.5;
-	color: var(--sbwscf-text-color);
+        padding: 1rem;
+        background-color: #f8f8f8;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        color: var(--sbwscf-text-color);
+}
+
+@media (max-width: 640px) {
+        .sbwscf-cookie-category {
+                --sbwscf-toggle-width: 100%;
+        }
+
+        .sbwscf-cookie-summary {
+                padding-right: 1rem;
+        }
+
+        .sbwscf-cookie-toggle {
+                position: static;
+                width: 100%;
+                justify-content: flex-start;
+                border-left: none;
+                border-top: 1px solid #ddd;
+                border-bottom: none;
+        }
+
+        .sbwscf-cookie-accordion[open] ~ .sbwscf-cookie-toggle {
+                border-bottom: 1px solid #ddd;
+        }
 }
 
 .sbwscf-cookie-description span {

--- a/includes/tabs/cookies/cookies-endpoint.php
+++ b/includes/tabs/cookies/cookies-endpoint.php
@@ -155,27 +155,29 @@ function sbwscf_output_cookie_consent_panel(): void {
 
 		<div id="sbwscf-cookie-categories" class="sbwscf-cookie-categories" hidden>
 						<strong class="sbwscf-smile-cookies-title"><?php echo esc_html( $preferences_label ); ?></strong>
-			<details class="sbwscf-cookie-category">
-				<summary class="sbwscf-cookie-summary">
-										<span class="sbwscf-cookie-title"><?php echo wp_kses( $functional_title, sbwscf_get_cookie_inline_allowed_tags() ); ?></span>
-					<span>
-						<label class="sbwscf-cookie-checkbox" for="sbwscf-functional-always-active">
-							<input type="checkbox" id="sbwscf-functional-always-active" name="sbwscf_cookie_functional" checked
-								disabled aria-disabled="true" />
-							<?php esc_html_e( 'Always active', 'smile-basic-web' ); ?>
-						</label>
-					</span>
-				</summary>
-								<div class="sbwscf-cookie-description">
-										<?php
-										if ( '' !== trim( wp_strip_all_tags( (string) $functional_description ) ) ) {
-												echo wp_kses_post( wpautop( $functional_description ) );
-										} else {
-												esc_html_e( 'Technical storage or access is strictly necessary to enable the use of a specific service explicitly requested by the user or to carry out the transmission of a communication over an electronic communications network.', 'smile-basic-web' );
-										}
-										?>
-								</div>
-			</details>
+                        <div class="sbwscf-cookie-category">
+                                <details class="sbwscf-cookie-accordion">
+                                        <summary class="sbwscf-cookie-summary" id="sbwscf-functional-summary">
+                                                                                <span class="sbwscf-cookie-title"><?php echo wp_kses( $functional_title, sbwscf_get_cookie_inline_allowed_tags() ); ?></span>
+                                        </summary>
+                                                                <div class="sbwscf-cookie-description">
+                                                                                <?php
+                                                                                if ( '' !== trim( wp_strip_all_tags( (string) $functional_description ) ) ) {
+                                                                                                echo wp_kses_post( wpautop( $functional_description ) );
+                                                                                } else {
+                                                                                                esc_html_e( 'Technical storage or access is strictly necessary to enable the use of a specific service explicitly requested by the user or to carry out the transmission of a communication over an electronic communications network.', 'smile-basic-web' );
+                                                                                }
+                                                                                ?>
+                                                                </div>
+                                </details>
+                                <div class="sbwscf-cookie-toggle" role="group" aria-labelledby="sbwscf-functional-summary">
+                                        <label class="sbwscf-cookie-checkbox" for="sbwscf-functional-always-active">
+                                                <input type="checkbox" id="sbwscf-functional-always-active" name="sbwscf_cookie_functional" checked
+                                                        disabled aria-disabled="true" />
+                                                <?php esc_html_e( 'Always active', 'smile-basic-web' ); ?>
+                                        </label>
+                                </div>
+                        </div>
 
 			<?php
 			$scripts = get_option( 'sbwscf_tracking_scripts', array() );
@@ -192,18 +194,25 @@ function sbwscf_output_cookie_consent_panel(): void {
 					if ( '' !== $slug && $has_description ) :
 						$input_id = 'sbwscf-optin-' . $i;
 						?>
-						<details class="sbwscf-cookie-category">
-								<summary class="sbwscf-cookie-summary">
-										<span class="sbwscf-cookie-title"><?php echo wp_kses( sbwscf_format_cookie_inline_html( $name ), sbwscf_get_cookie_inline_allowed_tags() ); ?></span>
-										<span class="sbwscf-cookie-checkbox">
-												<input type="checkbox" id="<?php echo esc_attr( $input_id ); ?>" data-category="<?php echo esc_attr( $slug ); ?>" />
-												<label for="<?php echo esc_attr( $input_id ); ?>"><?php esc_html_e( 'Enable', 'smile-basic-web' ); ?></label>
-										</span>
-								</summary>
-								<div class="sbwscf-cookie-description">
-						<?php echo wp_kses_post( wpautop( $description ) ); ?>
-								</div>
-						</details>
+                                                <?php
+                                                $summary_id = 'sbwscf-cookie-summary-' . $i;
+                                                ?>
+                                                <div class="sbwscf-cookie-category">
+                                                                <details class="sbwscf-cookie-accordion">
+                                                                                <summary class="sbwscf-cookie-summary" id="<?php echo esc_attr( $summary_id ); ?>">
+                                                                                <span class="sbwscf-cookie-title"><?php echo wp_kses( sbwscf_format_cookie_inline_html( $name ), sbwscf_get_cookie_inline_allowed_tags() ); ?></span>
+                                                                                </summary>
+                                                                                <div class="sbwscf-cookie-description">
+                                                <?php echo wp_kses_post( wpautop( $description ) ); ?>
+                                                                                </div>
+                                                                </details>
+                                                                <div class="sbwscf-cookie-toggle" role="group" aria-labelledby="<?php echo esc_attr( $summary_id ); ?>">
+                                                                                <span class="sbwscf-cookie-checkbox">
+                                                                                                <input type="checkbox" id="<?php echo esc_attr( $input_id ); ?>" data-category="<?php echo esc_attr( $slug ); ?>" />
+                                                                                                <label for="<?php echo esc_attr( $input_id ); ?>"><?php esc_html_e( 'Enable', 'smile-basic-web' ); ?></label>
+                                                                                </span>
+                                                                </div>
+                                                </div>
 						<?php
 									endif;
 					endforeach;


### PR DESCRIPTION
## Summary
- wrap each cookie category in a container so toggles sit outside `<summary>` while staying visible in the collapsed state
- refresh the cookie panel styling to align the new structure and preserve the expected desktop and mobile presentation

## Testing
- php -l includes/tabs/cookies/cookies-endpoint.php

------
https://chatgpt.com/codex/tasks/task_e_68f2168d376c8330bef13616e825660f